### PR TITLE
!HOTFIX/#12 Event CRUD 로직 내의 TypeORM findOne undefined error 수정

### DIFF
--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -27,13 +27,13 @@ export class EventsController {
 
   @Get()
   findAll(@Request() req: any) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.eventsService.findAllByUser(userId);
   }
 
   @Get(':id')
   findOne(@Request() req: any, @Param('id') id: string) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.eventsService.findOneByUser(userId, id);
   }
 
@@ -43,13 +43,13 @@ export class EventsController {
     @Param('id') id: string,
     @Body() dto: UpdateEventDto,
   ) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.eventsService.update(userId, id, dto);
   }
 
   @Delete(':id')
   remove(@Request() req: any, @Param('id') id: string) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.eventsService.remove(userId, id);
   }
 }


### PR DESCRIPTION
https://github.com/Calabi-Yau-Ontology/calabi-backend/blob/3f17a34492a7a729c200776dbe0bdcd5de7563d5/src/events/events.controller.ts#L24C5-L24C36
위의 const userId = req.user.userId;를 
const userId = req.user.id;로 수정하였습니다.


Closes #12 