### PR TITLE
Feat/#14 basic ontology construction

### DIFF
--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -21,7 +21,7 @@ export class EventsController {
 
   @Post()
   create(@Request() req: any, @Body() dto: CreateEventDto) {
-    const userId = req.user.userId;
+    const userId = req.user.id;
     return this.eventsService.create(userId, dto);
   }
 

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -3,10 +3,17 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventsService } from './events.service';
 import { EventsController } from './events.controller';
 import { Event } from './entities/event.entity';
-import { UsersModule } from '../users/users.module';
+import { UsersModule } from 'src/users/users.module';
+import { OntologyModule } from 'src/ontology/ontology.module';
+import { SuggestionsModule } from 'src/suggestions/suggestions.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Event]), UsersModule],
+  imports: [
+    TypeOrmModule.forFeature([Event]), 
+    UsersModule, 
+    OntologyModule, 
+    SuggestionsModule
+  ],
   controllers: [EventsController],
   providers: [EventsService],
 })

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -95,8 +95,9 @@ export class EventsService {
 
   async remove(userId: string, id: string): Promise<{ deleted: boolean }> {
     const event = await this.findOneByUser(userId, id);
+    const eventId = event.id;
     await this.eventsRepo.remove(event);
-    await this.ontologyService.removeEvent(event.id);
+    await this.ontologyService.removeEvent(eventId);
     return { deleted: true };
   }
 }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -5,6 +5,8 @@ import { Event } from './entities/event.entity';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
 import { UsersService } from '../users/users.service';
+import { OntologyService } from 'src/ontology/ontology.service';
+import { SuggestionsService } from 'src/suggestions/suggestions.service';
 
 @Injectable()
 export class EventsService {
@@ -12,6 +14,8 @@ export class EventsService {
     @InjectRepository(Event)
     private readonly eventsRepo: Repository<Event>,
     private readonly usersService: UsersService,
+    private readonly ontologyService: OntologyService,
+    private readonly suggestionsService: SuggestionsService,
   ) {}
 
   async create(userId: string, dto: CreateEventDto): Promise<Event> {
@@ -29,7 +33,16 @@ export class EventsService {
       location: dto.location,
     });
 
-    return this.eventsRepo.save(event);
+    // return this.eventsRepo.save(event);
+    const saved = await this.eventsRepo.save(event);
+
+    // NER 실행
+    const nerResult = await this.suggestionsService.runNer({ text: saved.title + ' ' + saved.description });
+
+    // Ontology 반영
+    await this.ontologyService.processEventOntology(userId, saved, nerResult);
+
+    return saved;
   }
 
   findAllByUser(userId: string): Promise<Event[]> {
@@ -63,8 +76,17 @@ export class EventsService {
     if (dto.endTime !== undefined)
       event.endTime = dto.endTime ? new Date(dto.endTime) : null;
     if (dto.location !== undefined) event.location = dto.location;
+    
+    // return this.eventsRepo.save(event);
+    const saved = await this.eventsRepo.save(event);
 
-    return this.eventsRepo.save(event);
+    // NER 실행
+    const nerResult = await this.suggestionsService.runNer({ text: saved.title + ' ' + saved.description });
+
+    // Ontology 반영
+    await this.ontologyService.processEventOntology(userId, saved, nerResult);
+
+    return saved;
   }
 
   async remove(userId: string, id: string): Promise<{ deleted: boolean }> {

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -37,10 +37,12 @@ export class EventsService {
     const saved = await this.eventsRepo.save(event);
 
     // NER 실행
-    const nerResult = await this.suggestionsService.runNer({ text: saved.title + ' ' + saved.description });
+    const nerResult = await this.suggestionsService.runNer({
+      text: `${saved.title ?? ''} ${saved.description ?? ''}`.trim(),
+    });
 
     // Ontology 반영
-    await this.ontologyService.processEventOntology(userId, saved, nerResult);
+    await this.ontologyService.processEventOntology(saved.user, saved, nerResult);
 
     return saved;
   }
@@ -81,10 +83,12 @@ export class EventsService {
     const saved = await this.eventsRepo.save(event);
 
     // NER 실행
-    const nerResult = await this.suggestionsService.runNer({ text: saved.title + ' ' + saved.description });
+    const nerResult = await this.suggestionsService.runNer({
+      text: `${saved.title ?? ''} ${saved.description ?? ''}`.trim(),
+    });
 
     // Ontology 반영
-    await this.ontologyService.processEventOntology(userId, saved, nerResult);
+    await this.ontologyService.processEventOntology(saved.user, saved, nerResult);
 
     return saved;
   }
@@ -92,6 +96,7 @@ export class EventsService {
   async remove(userId: string, id: string): Promise<{ deleted: boolean }> {
     const event = await this.findOneByUser(userId, id);
     await this.eventsRepo.remove(event);
+    await this.ontologyService.removeEvent(event.id);
     return { deleted: true };
   }
 }

--- a/src/ontology/constants/concept-mapping.ts
+++ b/src/ontology/constants/concept-mapping.ts
@@ -1,0 +1,7 @@
+export const NER_TO_CONCEPT_TYPE = {
+  'Activity': 'ActivityType',
+  'Location': 'Location',
+  'Person': 'Person',
+  'Project': 'Project',
+  'Topic': 'Interest',
+};

--- a/src/ontology/constants/relations.ts
+++ b/src/ontology/constants/relations.ts
@@ -1,0 +1,5 @@
+export const RELATIONS = {
+  OWNS_EVENT: 'OWNS_EVENT',
+  MENTIONS: 'MENTIONS',
+  RELATED_TO: 'RELATED_TO',
+};

--- a/src/ontology/ontology.module.ts
+++ b/src/ontology/ontology.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { OntologyService } from './ontology.service';
 
 @Module({
-  providers: [OntologyService]
+  providers: [OntologyService],
+  exports: [OntologyService],
 })
 export class OntologyModule {}

--- a/src/ontology/ontology.service.ts
+++ b/src/ontology/ontology.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Neo4jService } from 'src/neo4j/neo4j.service';
 import { NER_TO_CONCEPT_TYPE } from './constants/concept-mapping';
+import { RELATIONS } from './constants/relations';
 import { Event } from 'src/events/entities/event.entity';
 import { NerResponseDto } from 'src/suggestions/dto/ner-response.dto';
 import { User } from 'src/users/entities/user.entity';
@@ -70,7 +71,7 @@ export class OntologyService {
     const cypher = `
       MATCH (e:Event {eventId: $eventId})
       MATCH (c:Concept {name: $conceptName})
-      MERGE (e)-[:MENTIONS]->(c)
+      MERGE (e)-[:${RELATIONS.MENTIONS}]->(c)
     `;
     await this.neo4j.run(cypher, { eventId, conceptName });
   }
@@ -79,7 +80,7 @@ export class OntologyService {
     const cypher = `
       MATCH (u:User {id: $userId})
       MATCH (c:Concept {name: $conceptName})
-      MERGE (u)-[:RELATED_TO]->(c)
+      MERGE (u)-[:${RELATIONS.RELATED_TO}]->(c)
     `;
     await this.neo4j.run(cypher, { userId, conceptName });
   }
@@ -88,7 +89,7 @@ export class OntologyService {
     const cypher = `
       MATCH (u:User {id: $userId})
       MATCH (e:Event {eventId: $eventId})
-      MERGE (u)-[:CREATED]->(e)
+      MERGE (u)-[:${RELATIONS.OWNS_EVENT}]->(e)
     `;
     await this.neo4j.run(cypher, { userId, eventId });
   }

--- a/src/ontology/ontology.service.ts
+++ b/src/ontology/ontology.service.ts
@@ -3,10 +3,59 @@ import { Neo4jService } from 'src/neo4j/neo4j.service';
 import { NER_TO_CONCEPT_TYPE } from './constants/concept-mapping';
 import { Event } from 'src/events/entities/event.entity';
 import { NerResponseDto } from 'src/suggestions/dto/ner-response.dto';
+import { User } from 'src/users/entities/user.entity';
 
 @Injectable()
 export class OntologyService {
   constructor(private readonly neo4j: Neo4jService) {}
+
+  private toDateTimeString(date?: Date | null): string | null {
+    return date ? date.toISOString() : null;
+  }
+
+  async upsertUser(user: User) {
+    const cypher = `
+      MERGE (u:User { id: $id })
+      ON CREATE SET u.createdAt = datetime($createdAt)
+      SET u.email = $email,
+          u.updatedAt = datetime($updatedAt)
+      RETURN u
+    `;
+    const now = new Date().toISOString();
+    await this.neo4j.run(cypher, {
+      id: user.id,
+      email: user.email,
+      createdAt: this.toDateTimeString(user.createdAt) ?? now,
+      updatedAt: this.toDateTimeString(user.updatedAt) ?? now,
+    });
+  }
+
+  async upsertEvent(event: Event) {
+    const cypher = `
+      MERGE (e:Event { eventId: $eventId })
+      ON CREATE SET e.createdAt = datetime($createdAt)
+      SET e.title = $title,
+          e.description = $description,
+          e.location = $location,
+          e.startTime = datetime($startTime),
+          e.endTime = CASE
+            WHEN $endTime IS NULL THEN NULL
+            ELSE datetime($endTime)
+          END,
+          e.updatedAt = datetime($updatedAt)
+      RETURN e
+    `;
+    await this.neo4j.run(cypher, {
+      eventId: event.id,
+      title: event.title,
+      description: event.description ?? null,
+      location: event.location ?? null,
+      startTime: this.toDateTimeString(event.startTime),
+      endTime: this.toDateTimeString(event.endTime ?? null),
+      createdAt: this.toDateTimeString(event.createdAt) ?? new Date().toISOString(),
+      updatedAt: this.toDateTimeString(event.updatedAt) ?? new Date().toISOString(),
+    });
+  }
 
   async upsertConcept(name: string, type: string) {
     const cypher = `
@@ -35,14 +84,48 @@ export class OntologyService {
     await this.neo4j.run(cypher, { userId, conceptName });
   }
 
-  async processEventOntology(userId: string, event: Event, ner: NerResponseDto) {
-    console.log('Processing ontology for event:', event.id);
-    console.log('NER result:', ner);
-    for (const ent of ner.entities) {
+  async linkUserToEvent(userId: string, eventId: string) {
+    const cypher = `
+      MATCH (u:User {id: $userId})
+      MATCH (e:Event {eventId: $eventId})
+      MERGE (u)-[:CREATED]->(e)
+    `;
+    await this.neo4j.run(cypher, { userId, eventId });
+  }
+
+  async clearEventConceptLinks(eventId: string) {
+    const cypher = `
+      MATCH (e:Event {eventId: $eventId})-[rel:MENTIONS]->(:Concept)
+      DELETE rel
+    `;
+    await this.neo4j.run(cypher, { eventId });
+  }
+
+  async removeEvent(eventId: string) {
+    const cypher = `
+      MATCH (e:Event {eventId: $eventId})
+      DETACH DELETE e
+    `;
+    await this.neo4j.run(cypher, { eventId });
+  }
+
+  async processEventOntology(user: User, event: Event, ner: NerResponseDto) {
+    const entities = ner?.entities ?? [];
+
+    await this.upsertUser(user);
+    await this.upsertEvent(event);
+    await this.linkUserToEvent(user.id, event.id);
+    await this.clearEventConceptLinks(event.id);
+
+    for (const ent of entities) {
+      const conceptName = ent.text?.trim();
+      if (!conceptName) {
+        continue;
+      }
       const conceptType = NER_TO_CONCEPT_TYPE[ent.label] ?? 'Concept';
-      await this.upsertConcept(ent.text, conceptType);
-      await this.linkEventToConcept(event.id, ent.text);
-      await this.linkUserToConcept(userId, ent.text);
+      await this.upsertConcept(conceptName, conceptType);
+      await this.linkEventToConcept(event.id, conceptName);
+      await this.linkUserToConcept(user.id, conceptName);
     }
   }
 }

--- a/src/ontology/ontology.service.ts
+++ b/src/ontology/ontology.service.ts
@@ -1,4 +1,48 @@
 import { Injectable } from '@nestjs/common';
+import { Neo4jService } from 'src/neo4j/neo4j.service';
+import { NER_TO_CONCEPT_TYPE } from './constants/concept-mapping';
+import { Event } from 'src/events/entities/event.entity';
+import { NerResponseDto } from 'src/suggestions/dto/ner-response.dto';
 
 @Injectable()
-export class OntologyService {}
+export class OntologyService {
+  constructor(private readonly neo4j: Neo4jService) {}
+
+  async upsertConcept(name: string, type: string) {
+    const cypher = `
+      MERGE (c:Concept:${type} { name: $name })
+      ON CREATE SET c.createdAt = datetime()
+      RETURN c
+    `;
+    return this.neo4j.run(cypher, { name });
+  }
+
+  async linkEventToConcept(eventId: string, conceptName: string) {
+    const cypher = `
+      MATCH (e:Event {eventId: $eventId})
+      MATCH (c:Concept {name: $conceptName})
+      MERGE (e)-[:MENTIONS]->(c)
+    `;
+    await this.neo4j.run(cypher, { eventId, conceptName });
+  }
+
+  async linkUserToConcept(userId: string, conceptName: string) {
+    const cypher = `
+      MATCH (u:User {id: $userId})
+      MATCH (c:Concept {name: $conceptName})
+      MERGE (u)-[:RELATED_TO]->(c)
+    `;
+    await this.neo4j.run(cypher, { userId, conceptName });
+  }
+
+  async processEventOntology(userId: string, event: Event, ner: NerResponseDto) {
+    console.log('Processing ontology for event:', event.id);
+    console.log('NER result:', ner);
+    for (const ent of ner.entities) {
+      const conceptType = NER_TO_CONCEPT_TYPE[ent.label] ?? 'Concept';
+      await this.upsertConcept(ent.text, conceptType);
+      await this.linkEventToConcept(event.id, ent.text);
+      await this.linkUserToConcept(userId, ent.text);
+    }
+  }
+}

--- a/src/suggestions/suggestions.service.ts
+++ b/src/suggestions/suggestions.service.ts
@@ -8,6 +8,8 @@ import { AxiosError } from 'axios';
 import { Event } from '../events/entities/event.entity';
 import { SuggestRequestDto } from './dto/suggest-request.dto';
 import { SuggestResponseDto } from './dto/suggest-response.dto';
+import { NerResponseDto } from './dto/ner-response.dto';
+import { RunNerDto } from './dto/run-ner.dto';
 
 @Injectable()
 export class SuggestionsService {
@@ -24,14 +26,11 @@ export class SuggestionsService {
     this.baseUrl = mlConfig.baseUrl;
   }
 
-  /**
-   * 단순 NER 프록시 (이미 구현돼 있다면 그대로 두면 됨)
-   */
-  async runNer(text: string) {
+  async runNer(text: RunNerDto): Promise<NerResponseDto> {
     const url = `${this.baseUrl}/nlp/ner`;
 
     try {
-      const response$ = this.httpService.post(url, { text });
+      const response$ = this.httpService.post(url, text);
       const { data } = await firstValueFrom(response$);
       return data;
     } catch (error) {


### PR DESCRIPTION
## 작업 내용

- [x] Neo4j에 다음과 같은 Label, Relation 정의 (우선 최소 필요 타입만)
    - Label
        - :Concept (상위 Label)
            - :Interest, :ActivityType, :Location, :Person, :Project (Sub Label)
    - Relation
        - (User)-[:OWNS_EVENT]->(Event)
        - (Event)-[:MENTIONS]->(Concept)
        - (User)-[:RELATED_TO]->(Concept)
        - etc...
- [x] OntologyService 구현
    - Concept 노드 MERGE (upsert)
    - Event–Concept 연결
    - User–Concept 연결
    - Event 저장/수정 시 전체 파이프라인 실행
    - User, Event 노드 MERGE (upsert)
- [x] Event 저장, 수정, 삭제 로직에 Ontology pipeline 연동
    - Event 생성 -> NER 호출 -> Concept 매핑 -> Neo4j 반영

---

## 예시

### 1. Event 생성 시

**[ Event 생성 ]**
<img width="935" height="819" alt="image" src="https://github.com/user-attachments/assets/bff4c6f7-0a13-4db2-8d3a-0f575fd1ccbc" />

**[ Neo4j 결과 ]**
<img width="1252" height="524" alt="image" src="https://github.com/user-attachments/assets/d9dfce22-c8f8-4de5-9306-e831c0083975" />
- Event, User, Concept Node들 Upsert되고, 관계도 생성된 모습 

### 2. Event 삭제 시

**[ Event 삭제 ]**
<img width="687" height="561" alt="image" src="https://github.com/user-attachments/assets/71ede331-2006-4301-8067-1d15b6c069df" />

**[ Neo4j 결과 ]**
<img width="1252" height="523" alt="image" src="https://github.com/user-attachments/assets/12e70d5f-7709-4839-9119-ac57920eb389" />
- Event DETACH DELETE된 모습 

Closes #14 