### PR TITLE
Feat/#21 concept based wiki neighborhood extension

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -27,4 +27,9 @@ export default () => ({
   ml: {
     baseUrl: process.env.ML_BASE_URL ?? 'http://localhost:8000',
   },
+  wikidata: {
+    sparqlEndpoint: process.env.WIKIDATA_SPARQL_ENDPOINT,
+    searchEndpoint: process.env.WIKIDATA_SEARCH_ENDPOINT,
+    language: process.env.WIKIDATA_LANGUAGE || 'ko,en',
+  },
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -8,31 +8,43 @@ class EnvironmentVariables {
 
   @IsString()
   POSTGRES_HOST!: string;
-
   @IsString()
   POSTGRES_PORT!: string;
-
   @IsString()
   POSTGRES_USER!: string;
-
   @IsString()
   POSTGRES_PASSWORD!: string;
-
   @IsString()
   POSTGRES_DB!: string;
 
   @IsString()
   JWT_SECRET!: string;
-
   @IsOptional()
   @IsString()
   JWT_EXPIRES_IN?: string;
 
   @IsString()
   APP_NEO4J_URI!: string;
-
   @IsString()
   NEO4J_AUTH!: string;
+
+  @IsString()
+  ML_BASE_URL!: string;
+
+  @IsString()
+  GOOGLE_CLIENT_ID!: string;
+  @IsString()
+  GOOGLE_CLIENT_SECRET!: string;
+  @IsString()
+  GOOGLE_REDIRECT_URI!: string;
+
+  @IsString()
+  WIKIDATA_SPARQL_ENDPOINT?: string;
+  @IsString()
+  WIKIDATA_SEARCH_ENDPOINT?: string;
+  @IsOptional()
+  @IsString()
+  WIKIDATA_LANGUAGE?: string;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/src/ontology/constants/relations.ts
+++ b/src/ontology/constants/relations.ts
@@ -2,4 +2,12 @@ export const RELATIONS = {
   OWNS_EVENT: 'OWNS_EVENT',
   MENTIONS: 'MENTIONS',
   RELATED_TO: 'RELATED_TO',
-};
+
+  INSTANCE_OF: 'INSTANCE_OF',
+  SUBCLASS_OF: 'SUBCLASS_OF',
+  HAS_PART: 'HAS_PART',
+  HAS_GOAL: 'HAS_GOAL',
+} as const;
+
+export type RelationKey = keyof typeof RELATIONS;
+export type RelationValue = (typeof RELATIONS)[RelationKey];

--- a/src/ontology/ontology.module.ts
+++ b/src/ontology/ontology.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { OntologyService } from './ontology.service';
+import { WikidataModule } from 'src/wikidata/wikidata.module';
 
 @Module({
+  imports:[WikidataModule],
   providers: [OntologyService],
   exports: [OntologyService],
 })

--- a/src/ontology/ontology.service.ts
+++ b/src/ontology/ontology.service.ts
@@ -67,7 +67,6 @@ export class OntologyService {
     type: string,
     opts?: { externalId?: string; source?: string },
   ) {
-    console.log("given args:", name, type, opts);
     const cypher = `
       MERGE (c:Concept:${type} { name: $name })
       ON CREATE SET
@@ -101,9 +100,7 @@ export class OntologyService {
 
     // 2) Wikidata 검색
     const entity = await this.wikidata.searchEntity(name);
-    console.log('ff:', entity);
     if (!entity) return;
-    console.log("check 1");
 
     const qid = entity.id; // Q번호
 
@@ -112,7 +109,6 @@ export class OntologyService {
       externalId: qid,
       source: 'wikidata',
     });
-    console.log("check 2");
 
     // 4) 이웃 가져오기
     const neighbors = await this.wikidata.fetchNeighbors(qid);

--- a/src/ontology/ontology.service.ts
+++ b/src/ontology/ontology.service.ts
@@ -1,14 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { Neo4jService } from 'src/neo4j/neo4j.service';
 import { NER_TO_CONCEPT_TYPE } from './constants/concept-mapping';
-import { RELATIONS } from './constants/relations';
+import { WikidataService } from 'src/wikidata/wikidata.service';
+import { RELATIONS, RelationValue } from './constants/relations';
 import { Event } from 'src/events/entities/event.entity';
 import { NerResponseDto } from 'src/suggestions/dto/ner-response.dto';
 import { User } from 'src/users/entities/user.entity';
 
 @Injectable()
 export class OntologyService {
-  constructor(private readonly neo4j: Neo4jService) {}
+  constructor(
+    private readonly neo4j: Neo4jService,
+    private readonly wikidata: WikidataService,
+  ) {}
 
   private toDateTimeString(date?: Date | null): string | null {
     return date ? date.toISOString() : null;
@@ -58,13 +62,93 @@ export class OntologyService {
     });
   }
 
-  async upsertConcept(name: string, type: string) {
+  async upsertConcept(
+    name: string,
+    type: string,
+    opts?: { externalId?: string; source?: string },
+  ) {
+    console.log("given args:", name, type, opts);
     const cypher = `
       MERGE (c:Concept:${type} { name: $name })
-      ON CREATE SET c.createdAt = datetime()
+      ON CREATE SET
+        c.createdAt = datetime()
+      SET
+        c.externalId = COALESCE($externalId, c.externalId),
+        c.source = COALESCE($source, c.source),
+        c.updatedAt = datetime()
       RETURN c
     `;
-    return this.neo4j.run(cypher, { name });
+
+    await this.neo4j.run(cypher, {
+      name,
+      externalId: opts?.externalId ?? null,
+      source: opts?.source ?? null,
+    });
+  }
+
+  async expandConceptFromWikidata(name: string, type: string) {
+    // 1) Concept 이미 externalId가 있다면, 재확장하지 않도록 early return (optional)
+    const checkCypher = `
+      MATCH (c:Concept:${type} {name: $name})
+      RETURN c.externalId AS externalId
+    `;
+    const result = await this.neo4j.run(checkCypher, { name });
+    const existing = result.records?.[0]?.get?.('externalId');
+    if (existing) {
+      // 이미 Wikidata 연동된 Concept라면 확장 스킵
+      return;
+    }
+
+    // 2) Wikidata 검색
+    const entity = await this.wikidata.searchEntity(name);
+    console.log('ff:', entity);
+    if (!entity) return;
+    console.log("check 1");
+
+    const qid = entity.id; // Q번호
+
+    // 3) Concept 노드에 externalId / source 업데이트
+    await this.upsertConcept(name, type, {
+      externalId: qid,
+      source: 'wikidata',
+    });
+    console.log("check 2");
+
+    // 4) 이웃 가져오기
+    const neighbors = await this.wikidata.fetchNeighbors(qid);
+    if (!neighbors.length) return;
+
+    // 5) 이웃 Concept upsert + 관계 생성
+    for (const nb of neighbors) {
+      const neighborType = 'Concept'; // 일단 타입은 generic, 나중에 분류 가능
+
+      await this.upsertConcept(nb.label, neighborType, {
+        externalId: nb.id,
+        source: 'wikidata',
+      });
+
+      let relation: RelationValue;
+      if (nb.relation === 'INSTANCE_OF') relation = RELATIONS.INSTANCE_OF;
+      else if (nb.relation === 'SUBCLASS_OF') relation = RELATIONS.SUBCLASS_OF;
+      else if (nb.relation === 'HAS_PART') relation = RELATIONS.HAS_PART;
+      else relation = RELATIONS.HAS_GOAL;
+
+      await this.linkConceptToConcept(name, nb.label, relation);
+    }
+  }
+
+  async linkConceptToConcept(
+    fromName: string,
+    toName: string,
+    relation: RelationValue,
+  ) {
+    const cypher = `
+      MATCH (c1:Concept {name: $fromName})
+      MATCH (c2:Concept {name: $toName})
+      MERGE (c1)-[r:${relation}]->(c2)
+      RETURN r
+    `;
+    await this.neo4j.run(cypher, { fromName, toName });
   }
 
   async linkEventToConcept(eventId: string, conceptName: string) {
@@ -127,6 +211,14 @@ export class OntologyService {
       await this.upsertConcept(conceptName, conceptType);
       await this.linkEventToConcept(event.id, conceptName);
       await this.linkUserToConcept(user.id, conceptName);
+
+      // Wikidata 확장 (best-effort)
+      try {
+        await this.expandConceptFromWikidata(conceptName, conceptType);
+      } catch (e) {
+        // 절대 메인 플로우 깨지지 않게 로그만
+        console.error('Wikidata expansion failed', e);
+      }
     }
   }
 }

--- a/src/wikidata/wikidata.module.ts
+++ b/src/wikidata/wikidata.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigModule } from '@nestjs/config';
+import { WikidataService } from './wikidata.service';
+
+@Module({
+  imports: [
+    HttpModule.register({
+      timeout: 5000,
+      maxRedirects: 5,
+      headers: {
+        'User-Agent': 'CalabiBot/0.1 (https://calabi.example; contact@example.com)',
+      },
+    }),
+    ConfigModule,
+  ],
+  providers: [WikidataService],
+  exports: [WikidataService],
+})
+export class WikidataModule {}

--- a/src/wikidata/wikidata.service.ts
+++ b/src/wikidata/wikidata.service.ts
@@ -49,7 +49,6 @@ export class WikidataService {
     try {
       const res$ = this.http.get(this.searchEndpoint, { params });
       const { data } = await firstValueFrom(res$);
-      console.log('data: ', data);
 
       if (!data?.search?.length) return null;
 
@@ -88,7 +87,6 @@ export class WikidataService {
     try {
       const res$ = this.http.get(this.sparqlEndpoint, { params });
       const { data } = await firstValueFrom(res$);
-      console.log("result of fetch nei: ", data);
       const results = data?.results?.bindings ?? [];
 
       const neighbors: WikidataNeighbor[] = [];

--- a/src/wikidata/wikidata.service.ts
+++ b/src/wikidata/wikidata.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+import { AxiosError } from 'axios';
+
+type WikidataSearchResult = {
+  id: string;       // Q번호 (예: "Q12345")
+  label: string;    // 라벨
+  description?: string;
+};
+
+type WikidataNeighbor = {
+  id: string;           // Q번호
+  label: string;
+  relation: 'INSTANCE_OF' | 'SUBCLASS_OF' | 'HAS_PART' | 'HAS_GOAL';
+};
+
+@Injectable()
+export class WikidataService {
+  private readonly logger = new Logger(WikidataService.name);
+  private readonly sparqlEndpoint: string;
+  private readonly searchEndpoint: string;
+  private readonly language: string;
+
+  constructor(
+    private readonly http: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    const cfg = this.configService.get('wikidata');
+    this.sparqlEndpoint = cfg.sparqlEndpoint;
+    this.searchEndpoint = cfg.searchEndpoint;
+    this.language = cfg.language || 'ko,en';
+  }
+
+  /**
+   * 텍스트(label)로 Wikidata 엔티티 검색 → QID 하나 반환
+   */
+  async searchEntity(label: string): Promise<WikidataSearchResult | null> {
+    const params = {
+      action: 'wbsearchentities',
+      format: 'json',
+      language: this.language.split(',')[0],
+      search: label,
+      limit: 1,
+      origin: '*',
+    };
+
+    try {
+      const res$ = this.http.get(this.searchEndpoint, { params });
+      const { data } = await firstValueFrom(res$);
+      console.log('data: ', data);
+
+      if (!data?.search?.length) return null;
+
+      const first = data.search[0];
+      return {
+        id: first.id, // "Qxxxx"
+        label: first.label,
+        description: first.description,
+      };
+    } catch (e) {
+      const err = e as AxiosError;
+      this.logger.error(`Wikidata search failed: ${err.message}`, err.stack);
+      return null;
+    }
+  }
+
+  /**
+   * 주어진 QID에 대해 instance of / subclass of / has part / has goal 이웃을 가져온다.
+   */
+  async fetchNeighbors(qid: string): Promise<WikidataNeighbor[]> {
+    const query = `
+      SELECT ?property ?propertyLabel ?value ?valueLabel WHERE {
+        VALUES ?item { wd:${qid} }
+        ?item ?p ?value .
+        ?property wikibase:directClaim ?p .
+        VALUES ?property { wd:P31 wd:P279 wd:P527 wd:P42 }
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "${this.language}" . }
+      }
+    `;
+
+    const params = {
+      query,
+      format: 'json',
+    };
+
+    try {
+      const res$ = this.http.get(this.sparqlEndpoint, { params });
+      const { data } = await firstValueFrom(res$);
+      console.log("result of fetch nei: ", data);
+      const results = data?.results?.bindings ?? [];
+
+      const neighbors: WikidataNeighbor[] = [];
+
+      for (const row of results) {
+        const propertyIri: string = row.property.value; // e.g. "http://www.wikidata.org/prop/direct/P31"
+        const valueIri: string = row.value.value;       // e.g. "http://www.wikidata.org/entity/Q12345"
+        const valueLabel: string = row.valueLabel?.value ?? '';
+
+        const pid = propertyIri.split('/').pop(); // "P31" etc.
+        const qid2 = valueIri.split('/').pop();   // "Qxxxx"
+
+        if (!qid2 || !valueLabel) continue;
+
+        let relation: WikidataNeighbor['relation'] | null = null;
+        if (pid === 'P31') relation = 'INSTANCE_OF';
+        else if (pid === 'P279') relation = 'SUBCLASS_OF';
+        else if (pid === 'P527') relation = 'HAS_PART';
+        else if (pid === 'P42') relation = 'HAS_GOAL';
+
+        if (!relation) continue;
+
+        neighbors.push({
+          id: qid2,
+          label: valueLabel,
+          relation,
+        });
+      }
+
+      return neighbors;
+    } catch (e) {
+      const err = e as AxiosError;
+      this.logger.error(`Wikidata neighbors fetch failed: ${err.message}`, err.stack);
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
wiki concept기반 이웃 확장 구현
- OntologyService.upsertConcept를 수정해 기존 Concept 노드라도 Wikidata에서 가져온externalId/source가 다시 덮어써지도록 변경. 따라서 이미 생성된 노드가 재처리돼도 Wikidata 정보가 누락되지 않음
- WikidataService.fetchNeighbors의 SPARQL 쿼리를 wd:P31/P279/P527/P42 형태로 조회하도록 수정, wikibase:directClaim과의 조합이 정상 작동하며 인접 관계를 반환.
- 두 변경으로 컨셉 노드에 Wikidata 메타데이터가 안정적으로 저장되며, INSTANCE_OF, SUBCLASS_OF 등 이웃 노드 확장이 제대로 이루어짐

테스트
- “기흥” 등 이벤트 입력 후 온톨로지 처리를 실행해 Concept 노드에 externalId/source가 채워지고 적절한 이웃 노드가 생성되는지 확인.