### PR TITLE
Fix/#40 neo4j wikidataqid field unify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,38 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# Calabi Backend
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Main API Server for a Calabi project that turns user events into structured knowledge. It manages users, categories, and events, then enriches event text through an ML NER service to drive consistency suggestions and a Neo4j-based ontology graph. The system also uses Redis caching and emits event stream messages for downstream processing.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+## Project Structure
 
 ```
 calabi-backend/
 ├── src
-│   ├── main.ts
 │   ├── app.module.ts
-│   ├── config
-│   │   ├── configuration.ts
-│   │   └── validation.ts
-│   ├── common
-│   │   ├── filters
-│   │   │   └── http-exception.filter.ts
-│   │   └── interceptors
-│   │       └── transform.interceptor.ts
-│   ├── database
-│   │   ├── database.module.ts
-│   │   └── ormconfig.ts
-│   ├── neo4j
-│   │   ├── neo4j.module.ts
-│   │   └── neo4j.service.ts
-│   ├── users
-│   │   ├── users.module.ts
-│   │   ├── users.controller.ts
-│   │   ├── users.service.ts
-│   │   ├── dto
-│   │   │   ├── create-user.dto.ts
-│   │   │   └── update-user.dto.ts
-│   │   └── entities
-│   │       └── user.entity.ts
+│   ├── main.ts
 │   ├── auth
-│   │   ├── auth.module.ts
-│   │   ├── auth.controller.ts
-│   │   ├── auth.service.ts
-│   │   ├── dto
-│   │   │   ├── login.dto.ts
-│   │   │   └── register.dto.ts
-│   │   └── strategies
-│   │       ├── jwt.strategy.ts
-│   │       └── local.strategy.ts
+│   ├── categories
+│   ├── common
+│   ├── config
+│   ├── database
 │   ├── events
-│   │   ├── events.module.ts
-│   │   ├── events.controller.ts
-│   │   ├── events.service.ts
-│   │   ├── dto
-│   │   │   ├── create-event.dto.ts
-│   │   │   └── update-event.dto.ts
-│   │   └── entities
-│   │       └── event.entity.ts
+│   ├── health
+│   ├── neo4j
+│   ├── ontology
+│   ├── redis
 │   ├── suggestions
-│   │   ├── suggestions.module.ts
-│   │   ├── suggestions.controller.ts
-│   │   ├── suggestions.service.ts
-│   │   └── dto
-│   │       └── suggest.dto.ts
-│   └── ontology
-│       ├── ontology.module.ts
-│       ├── ontology.service.ts
-│       └── dto
-│           └── create-node.dto.ts
+│   ├── users
+│   └── wikidata
+├── test
+│   ├── app.e2e-spec.ts
+│   └── jest-e2e.json
 ├── package.json
-├── tsconfig.json
-├── .env
-└── README.md
+└── tsconfig.json
 ```
 
-## License
+## Key Responsibilities
 
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+- User authentication and profile handling
+- Category and event CRUD for calendar data
+- NER-powered consistency suggestions with Redis cache
+- Ontology graph modeling in Neo4j with Wikidata expansion
+- Event stream publishing for real-time consumers

--- a/src/neo4j/migrations/2026-01-25_unify-concept-wikidataQid.cypher
+++ b/src/neo4j/migrations/2026-01-25_unify-concept-wikidataQid.cypher
@@ -1,0 +1,42 @@
+// 2026-01-25
+// 목적: Concept 노드의 Wikidata QID 필드를 `qid` → `wikidataQid`로 단일화
+//
+// 실행 위치:
+// - Neo4j Browser 또는 cypher-shell
+// - 운영/개발 DB 모두 "1회만" 실행
+//
+// 주의:
+// - 아래 0)에서 충돌(conflict)이 발견되면, 1)~2) 적용 전에 먼저 확인/정리 권장
+
+// 0) 사전 점검: qid와 wikidataQid가 모두 존재하지만 값이 다른 케이스
+MATCH (c:Concept)
+WHERE c.qid IS NOT NULL
+  AND c.wikidataQid IS NOT NULL
+  AND c.qid <> c.wikidataQid
+RETURN c.name AS name, c.qid AS qid, c.wikidataQid AS wikidataQid
+LIMIT 50;
+
+// 1) 마이그레이션: wikidataQid가 비어있으면 qid를 복사
+MATCH (c:Concept)
+WHERE c.qid IS NOT NULL
+  AND (c.wikidataQid IS NULL OR trim(toString(c.wikidataQid)) = "")
+SET c.wikidataQid = c.qid
+RETURN count(c) AS migratedCount;
+
+// 1b) 사후 점검: 동일 wikidataQid 중복 노드가 있는지 확인
+// - 과거에 (name, qid)로 MERGE 하면서 같은 qid가 중복 생성되었을 수 있음
+MATCH (c:Concept)
+WHERE c.wikidataQid IS NOT NULL AND trim(toString(c.wikidataQid)) <> ""
+WITH c.wikidataQid AS wikidataQid, collect(c) AS nodes, count(*) AS cnt
+WHERE cnt > 1
+RETURN wikidataQid, cnt, [n IN nodes | n.name][0..10] AS sampleNames
+ORDER BY cnt DESC
+LIMIT 50;
+
+// 2) 정리: legacy `qid` 프로퍼티 제거
+// - 충돌 케이스(qid != wikidataQid)는 정보를 잃지 않도록 남겨둔다.
+MATCH (c:Concept)
+WHERE c.qid IS NOT NULL
+  AND (c.wikidataQid IS NULL OR c.wikidataQid = c.qid)
+REMOVE c.qid
+RETURN count(c) AS removedLegacyQidCount;

--- a/src/neo4j/migrations/README.md
+++ b/src/neo4j/migrations/README.md
@@ -1,0 +1,10 @@
+# Neo4j one-time migrations
+
+This folder contains manual, one-time Cypher scripts intended to be run in Neo4j Browser or `cypher-shell`.
+
+## Run
+
+1. Open Neo4j Browser (e.g. `http://localhost:7474`) or use `cypher-shell`.
+2. Copy/paste the `.cypher` file contents and execute top-to-bottom.
+3. If the script includes a "pre-check" query, review results before applying writes.
+

--- a/src/neo4j/neo4j.schema.ts
+++ b/src/neo4j/neo4j.schema.ts
@@ -19,8 +19,10 @@ export const NEO4J_SCHEMA_STATEMENTS: string[] = [
    FOR (u:User) REQUIRE u.id IS UNIQUE`,
 
   // 확장 상태 조회 최적화
-  `CREATE INDEX concept_wikidata_qid_idx IF NOT EXISTS
-   FOR (c:Concept) ON (c.wikidataQid)`,
+  `DROP INDEX concept_wikidata_qid_idx IF EXISTS`,
+
+  `CREATE CONSTRAINT concept_wikidata_qid_unique IF NOT EXISTS
+   FOR (c:Concept) REQUIRE c.wikidataQid IS UNIQUE`,
 
   `CREATE INDEX concept_expanded_at_idx IF NOT EXISTS
    FOR (c:Concept) ON (c.wikidataExpandedAt)`

--- a/src/ontology/expansion/expansion.service.ts
+++ b/src/ontology/expansion/expansion.service.ts
@@ -95,7 +95,7 @@ export class ExpansionService {
   private async setConceptQid(name: string, qid: string): Promise<void> {
     const cypher = `
       MATCH (c:Concept { name: $name })
-      SET c.qid = $qid,
+      SET c.wikidataQid = $qid,
           c.source = "wikidata",
           c.updatedAt = datetime()
     `;
@@ -125,7 +125,7 @@ export class ExpansionService {
 
   /**
    * 중심 Concept와 Concept 이웃들을 연결한다.
-   * - Concept(name) ↔ Concept(qid) identity 연결
+   * - Concept(name) ↔ Concept(wikidataQid) identity 연결
    * - 각 neighbor를 Concept으로 upsert + label 저장
    * - Concept와 neighbor를 INSTANCE_OF / SUBCLASS_OF ... 관계로 직접 연결
    */
@@ -139,8 +139,10 @@ export class ExpansionService {
     const cypher = `
       UNWIND $edges AS e
       MATCH (c:Concept { name: $conceptName })
-      MERGE (n:Concept { name: e.neighborLabel, qid: e.neighborQid })
-      ON CREATE SET n.createdAt = datetime()
+      MERGE (n:Concept { wikidataQid: e.neighborQid })
+      ON CREATE SET
+        n.name = e.neighborLabel,
+        n.createdAt = datetime()
       SET n.updatedAt = datetime()
 
       FOREACH (_ IN CASE WHEN e.rel = 'INSTANCE_OF' THEN [1] ELSE [] END |


### PR DESCRIPTION
# Overview

Neo4j :Concept 노드의 Wikidata QID 저장 필드가 코드에서 qid와 wikidataQid로 혼용되고 있었어서

QID가 저장되어도 확장 로직이 "QID 없음"으로 판단해 불필요한 재검색/재저장을 유발할 수 있는 상황이었고,
인덱스도 사실상 의미없던 상황이라 이를 조치했음