### PR TITLE
Fix/#43 Ensure Entity Uniqueness

### DIFF
--- a/src/ontology/concept.service.ts
+++ b/src/ontology/concept.service.ts
@@ -24,7 +24,7 @@ export class ConceptService {
     if (!name) throw new Error('Concept name is empty');
 
     const cypher = `
-      MERGE (c:Concept { name: $name })
+      MERGE (c:Concept:${params.type} { name: $name, type: $type })
       ON CREATE SET
         c.id = randomUUID(),
         c.type = $type,
@@ -49,9 +49,9 @@ export class ConceptService {
     return result.records[0].get('concept');
   }
 
-  async getByName(name: string): Promise<ConceptNode | null> {
+  async getByName(name: string, type: ConceptType): Promise<ConceptNode | null> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $type })
       RETURN c {
         .id, .name, .type, .source,
         wikidataQid: c.wikidataQid,
@@ -59,30 +59,35 @@ export class ConceptService {
       } AS concept
       LIMIT 1
     `;
-    const res = await this.neo4j.run(cypher, { name: name.trim() });
+    const res = await this.neo4j.run(cypher, { name: name.trim(), type });
     return res.records.length ? res.records[0].get('concept') : null;
   }
 
   async markQidAndMaybeExpanded(params: {
     name: string;
+    type: ConceptType;
     qid: string;
     expanded: boolean;
   }): Promise<void> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $type })
       SET c.wikidataQid = $qid,
           c.updatedAt = datetime()
       ${params.expanded ? 'SET c.wikidataExpandedAt = datetime()' : ''}
     `;
-    await this.neo4j.run(cypher, { name: params.name.trim(), qid: params.qid });
+    await this.neo4j.run(cypher, {
+      name: params.name.trim(),
+      type: params.type,
+      qid: params.qid,
+    });
   }
 
-  async markExpanded(name: string): Promise<void> {
+  async markExpanded(name: string, type: ConceptType): Promise<void> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $type })
       SET c.wikidataExpandedAt = datetime(),
           c.updatedAt = datetime()
     `;
-    await this.neo4j.run(cypher, { name: name.trim() });
+    await this.neo4j.run(cypher, { name: name.trim(), type });
   }
 }

--- a/src/ontology/expansion/expansion.service.ts
+++ b/src/ontology/expansion/expansion.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Neo4jService } from 'src/neo4j/neo4j.service';
 import { WikidataService } from 'src/wikidata/wikidata.service';
 import { WikidataNeighbor } from 'src/wikidata/wikidata.types';
+import { ConceptType } from '../constants/concept.types';
 
 type ConceptRow = {
   name: string;
@@ -21,12 +22,13 @@ export class ExpansionService {
 
   async expandConceptByName(
     canonicalName: string,
+    conceptType: ConceptType,
   ): Promise<{ expanded: boolean; reason: string }> {
     const name = canonicalName.trim();
     if (!name) return { expanded: false, reason: 'empty_name' };
 
     // 1) Concept load
-    const concept = await this.getConceptRowByName(name);
+    const concept = await this.getConceptRowByName(name, conceptType);
     if (!concept) return { expanded: false, reason: 'concept_not_found' };
 
     // 2) guard: expandedAt 있으면 재확장 금지
@@ -39,10 +41,10 @@ export class ExpansionService {
     if (!qid) {
       qid = await this.resolveQidByCanonicalName(name);
       if (!qid) {
-        await this.markWikidataError(name, 'search_failed');
+        await this.markWikidataError(name, conceptType, 'search_failed');
         return { expanded: false, reason: 'qid_not_found' };
       }
-      await this.setConceptQid(name, qid);
+      await this.setConceptQid(name, conceptType, qid);
     }
 
     // 4) neighbors
@@ -51,24 +53,27 @@ export class ExpansionService {
     // console.log(`Fetched ${edges.length} neighbors for QID ${qid}`);
     if (!edges.length) {
       // neighbors 없더라도 지금은 “확장 완료”로 마킹
-      await this.markExpanded(name);
+      await this.markExpanded(name, conceptType);
       return { expanded: true, reason: 'expanded_no_neighbors' };
     }
 
     // 5) upsert neighbors + relations (idempotent)
-    await this.upsertNeighborhood(name, edges);
+    await this.upsertNeighborhood(name, conceptType, edges);
 
     // 6) expandedAt mark (마지막에)
-    await this.markExpanded(name);
+    await this.markExpanded(name, conceptType);
 
     return { expanded: true, reason: 'expanded' };
   }
 
   // ---------------- internal helpers ----------------
 
-  private async getConceptRowByName(name: string): Promise<ConceptRow | null> {
+  private async getConceptRowByName(
+    name: string,
+    conceptType: ConceptType,
+  ): Promise<ConceptRow | null> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $conceptType })
       RETURN {
         name: c.name,
         type: c.type,
@@ -77,7 +82,7 @@ export class ExpansionService {
       } AS c
       LIMIT 1
     `;
-    const res = await this.neo4j.run(cypher, { name });
+    const res = await this.neo4j.run(cypher, { name, conceptType });
     return res.records.length ? (res.records[0].get('c') as ConceptRow) : null;
   }
 
@@ -92,35 +97,43 @@ export class ExpansionService {
     return (exact?.id ?? results[0].id).trim();
   }
 
-  private async setConceptQid(name: string, qid: string): Promise<void> {
+  private async setConceptQid(
+    name: string,
+    conceptType: ConceptType,
+    qid: string,
+  ): Promise<void> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $conceptType })
       SET c.wikidataQid = $qid,
           c.source = "wikidata",
           c.updatedAt = datetime()
     `;
-    await this.neo4j.run(cypher, { name, qid });
+    await this.neo4j.run(cypher, { name, conceptType, qid });
   }
 
-  private async markExpanded(name: string): Promise<void> {
+  private async markExpanded(
+    name: string,
+    conceptType: ConceptType,
+  ): Promise<void> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $conceptType })
       SET c.wikidataExpandedAt = datetime(),
           c.updatedAt = datetime()
     `;
-    await this.neo4j.run(cypher, { name });
+    await this.neo4j.run(cypher, { name, conceptType });
   }
 
   private async markWikidataError(
     name: string,
+    conceptType: ConceptType,
     lastError: string,
   ): Promise<void> {
     const cypher = `
-      MATCH (c:Concept { name: $name })
+      MATCH (c:Concept { name: $name, type: $conceptType })
       SET c.wikidataLastError = $lastError,
           c.updatedAt = datetime()
     `;
-    await this.neo4j.run(cypher, { name, lastError });
+    await this.neo4j.run(cypher, { name, conceptType, lastError });
   }
 
   /**
@@ -131,6 +144,7 @@ export class ExpansionService {
    */
   private async upsertNeighborhood(
     conceptName: string,
+    conceptType: ConceptType,
     edges: WikidataNeighbor[],
   ): Promise<void> {
     if (!edges.length) return;
@@ -138,7 +152,7 @@ export class ExpansionService {
     // 각 neighbor를 Concept Node로 upsert하고 Concept에 rel 타입으로 연결
     const cypher = `
       UNWIND $edges AS e
-      MATCH (c:Concept { name: $conceptName })
+      MATCH (c:Concept { name: $conceptName, type: $conceptType })
       MERGE (n:Concept { wikidataQid: e.neighborQid })
       ON CREATE SET
         n.name = e.neighborLabel,
@@ -169,6 +183,7 @@ export class ExpansionService {
 
     await this.neo4j.run(cypher, {
       conceptName,
+      conceptType,
       edges: edges.map((edge) => ({
         neighborQid: edge.neighborQid,
         neighborLabel: edge.neighborLabel,

--- a/src/ontology/ontology.service.ts
+++ b/src/ontology/ontology.service.ts
@@ -122,22 +122,30 @@ export class OntologyService {
     });
   }
 
-  async linkEventToConcept(eventId: string, conceptName: string) {
+  async linkEventToConcept(
+    eventId: string,
+    conceptName: string,
+    conceptType: ConceptType,
+  ) {
     const cypher = `
       MATCH (e:Event { eventId: $eventId })
-      MATCH (c:Concept { name: $conceptName })
+      MATCH (c:Concept { name: $conceptName, type: $conceptType })
       MERGE (e)-[:${RELATIONS.MENTIONS}]->(c)
     `;
-    await this.neo4j.run(cypher, { eventId, conceptName });
+    await this.neo4j.run(cypher, { eventId, conceptName, conceptType });
   }
 
-  async linkUserToConcept(userId: string, conceptName: string) {
+  async linkUserToConcept(
+    userId: string,
+    conceptName: string,
+    conceptType: ConceptType,
+  ) {
     const cypher = `
       MATCH (u:User { id: $userId })
-      MATCH (c:Concept { name: $conceptName })
+      MATCH (c:Concept { name: $conceptName, type: $conceptType })
       MERGE (u)-[:${RELATIONS.RELATED_TO}]->(c)
     `;
-    await this.neo4j.run(cypher, { userId, conceptName });
+    await this.neo4j.run(cypher, { userId, conceptName, conceptType });
   }
 
   async linkUserToEvent(userId: string, eventId: string) {
@@ -229,8 +237,8 @@ export class OntologyService {
         conceptType,
         conceptProps,
       );
-      await this.linkEventToConcept(event.id, canonicalName);
-      await this.linkUserToConcept(user.id, canonicalName);
+      await this.linkEventToConcept(event.id, canonicalName, conceptType);
+      await this.linkUserToConcept(user.id, canonicalName, conceptType);
       await this.recordSurfaceForm(
         user.id,
         event.id,
@@ -240,9 +248,9 @@ export class OntologyService {
       );
     }
 
-    for (const { canonicalName } of concepts) {
+    for (const { canonicalName, conceptType } of concepts) {
       void this.expansionService
-        .expandConceptByName(canonicalName)
+        .expandConceptByName(canonicalName, conceptType)
         .catch((error: unknown) => {
           const message =
             error instanceof Error ? error.message : String(error);

--- a/src/suggestions/suggestions.service.ts
+++ b/src/suggestions/suggestions.service.ts
@@ -16,7 +16,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Neo4jService } from 'src/neo4j/neo4j.service';
 import { RELATIONS } from 'src/ontology/constants/relations';
-import { ConceptType, isAllowedNERLabel } from 'src/ontology/constants/concept.types';
+import {
+  ConceptType,
+  NER_TO_CONCEPT_TYPE,
+  isAllowedNERLabel,
+} from 'src/ontology/constants/concept.types';
 import { NerCacheService } from './cache/ner-cache.service';
 import type { NERResponseDto } from './dto/ner-response.dto';
 import type { RunNERDto } from './dto/run-ner.dto';
@@ -542,12 +546,17 @@ export class SuggestionsService {
     for (const mention of mentions) {
       const label = mention?.ner?.label;
       if (!isAllowedNERLabel(label)) continue;
+      const conceptType = NER_TO_CONCEPT_TYPE[label];
 
       const canonicalName = mention?.canonical?.en?.trim();
-      if (!canonicalName || map.has(canonicalName)) continue;
+      if (!canonicalName) continue;
 
-      map.set(canonicalName, {
+      const key = `${conceptType}::${canonicalName}`;
+      if (map.has(key)) continue;
+
+      map.set(key, {
         canonicalName,
+        conceptType,
         surface: mention?.surface?.trim() ?? null,
         span: mention?.span ?? null,
       });
@@ -567,7 +576,7 @@ export class SuggestionsService {
     const cypher = `
       MATCH (u:User { id: $userId })
       UNWIND $items AS item
-      MATCH (c:Concept { name: item.canonicalName })
+      MATCH (c:Concept { name: item.canonicalName, type: item.conceptType })
       CALL {
         WITH c, u
         MATCH (u)-[freqRel:${usageRel}]->(freq:SurfaceForm)-[:${surfaceRel}]->(c)

--- a/src/suggestions/types/graph.types.ts
+++ b/src/suggestions/types/graph.types.ts
@@ -37,6 +37,7 @@ export type ConsistencyRecommendationRow = {
 
 export type CanonicalMention = {
   canonicalName: string;
+  conceptType: ConceptType;
   surface?: string | null;
   span?: { start: number; end: number } | null;
 };


### PR DESCRIPTION
# Overview

type 없이 name만으로 Concept를 찾는 Cypher들이 존재해서 일관된 규칙 적용 및 버그 방지를 위해 작업

# 작업 내용

- Concept identity 규칙을 name+type으로 통일해 모든 쿼리가 타입을 포함하도록 변경
- Suggestions의 canonical mention 추출에 NER label 기반 conceptType을 추가하고 name과 type 조합으로 조회하도록 수정
- ConceptService 및 ExpansionService의 조회 및 업데이트가 name과 type 조합을 기준으로 작동하도록 수정

Closes #43 